### PR TITLE
Add note re: min from midday

### DIFF
--- a/docs/reference/object_types.md
+++ b/docs/reference/object_types.md
@@ -304,6 +304,8 @@ Name                | Group        | Value type description         | Value type
 
 These are the allowed types of values an attribute can store. Each attribute has a single, fixed value type.
 
+Note: value type `6` (minutes from midday) is reserved for attribute templates. New attributes cannot be created via the API with this value type.
+
 Value type description         | Value type 
 -------------------------------|-----------
 Integer quantity               | `0`


### PR DESCRIPTION
Added a note to value types section to mention minutes from midday type is only for templates.